### PR TITLE
Enhance task management with sorting, tags, and UI improvements

### DIFF
--- a/api/inngest.ts
+++ b/api/inngest.ts
@@ -1,7 +1,7 @@
 import { serve } from "inngest/node";
-import { inngest } from "./inngest/client";
-import { checkReminders } from "./inngest/functions/check-reminders";
-import { dailySummary } from "./inngest/functions/daily-summary";
+import { inngest } from "./inngest/client.js";
+import { checkReminders } from "./inngest/functions/check-reminders.js";
+import { dailySummary } from "./inngest/functions/daily-summary.js";
 
 export default serve({
   client: inngest,

--- a/api/inngest/functions/check-reminders.ts
+++ b/api/inngest/functions/check-reminders.ts
@@ -1,5 +1,5 @@
 import { Client, Databases, Query, Messaging } from "node-appwrite";
-import { inngest } from "../client";
+import { inngest } from "../client.js";
 
 const REMINDER_WINDOWS: Record<string, number> = {
   "1d": 24 * 60,

--- a/api/inngest/functions/daily-summary.ts
+++ b/api/inngest/functions/daily-summary.ts
@@ -1,5 +1,5 @@
 import { Client, Databases, Query, Messaging } from "node-appwrite";
-import { inngest } from "../client";
+import { inngest } from "../client.js";
 
 interface TaskDocument {
   $id: string;

--- a/scripts/setup-db.mjs
+++ b/scripts/setup-db.mjs
@@ -220,6 +220,7 @@ const TASKS = {
       elements: ["daily", "weekly", "monthly", "weekdays"],
       required: false,
     },
+    { key: "tags", type: "text", required: false },
     { key: "attachments", type: "text", required: false },
   ],
   indexes: [

--- a/src/features/tasks/components/empty-state.tsx
+++ b/src/features/tasks/components/empty-state.tsx
@@ -24,7 +24,7 @@ export function TaskEmptyState({
 }: TaskEmptyStateProps) {
   if (!showAddButton || !onAddTask) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-16rem)] px-4">
+      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-16rem)] px-4 animate-in fade-in slide-in-from-bottom-4 duration-500">
         <div className="mb-8">
           <img src={image} alt={imageAlt} className="w-64 h-64 object-contain" />
         </div>

--- a/src/features/tasks/components/task-add-dialog.tsx
+++ b/src/features/tasks/components/task-add-dialog.tsx
@@ -122,6 +122,8 @@ export function TaskAddDialog({
   const [reminderBefore, setReminderBefore] = React.useState<ReminderBefore>(
     task?.reminderBefore ?? "1h"
   );
+  const [tags, setTags] = React.useState<string[]>(task?.tags || []);
+  const [tagInput, setTagInput] = React.useState("");
   const [recurrence, setRecurrence] = React.useState<Recurrence | "">(task?.recurrence || "");
 
   // Update form when task changes
@@ -134,6 +136,7 @@ export function TaskAddDialog({
       setCategory(task.category || "");
       setProject(task.project || "");
       setSubtasks(task.subtasks || []);
+      setTags(task.tags || []);
       setReminderEnabled(task.reminderEnabled ?? false);
       setReminderBefore(task.reminderBefore ?? "1h");
       setRecurrence(task.recurrence || "");
@@ -157,6 +160,8 @@ export function TaskAddDialog({
     setSubtasks([]);
     setIsAddingSubtask(false);
     setAiPrioritySet(false);
+    setTags([]);
+    setTagInput("");
     setReminderEnabled(false);
     setReminderBefore("1h");
     setRecurrence("");
@@ -239,6 +244,7 @@ export function TaskAddDialog({
         priority,
         category: category.trim() || undefined,
         project: project.trim() || undefined,
+        tags: tags.length > 0 ? tags : undefined,
         status: task?.status || "todo",
         reminderEnabled: date ? reminderEnabled : false,
         reminderBefore: reminderEnabled && date ? reminderBefore : undefined,
@@ -486,6 +492,53 @@ export function TaskAddDialog({
               ]}
               onValueChange={(val) => setRecurrence(val as Recurrence | "")}
             />
+          </div>
+
+          {/* Tags Section */}
+          <div className="border-t pt-4 space-y-2">
+            <div className="flex items-center gap-2 flex-wrap">
+              {tags.map((tag, i) => (
+                <span
+                  key={i}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-indigo-500/10 text-indigo-500 text-xs font-medium"
+                >
+                  {tag}
+                  <button
+                    type="button"
+                    onClick={() => setTags(tags.filter((_, idx) => idx !== i))}
+                    className="hover:text-indigo-700"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+            <div className="flex items-center gap-2">
+              <Tag className="h-4 w-4 text-muted-foreground/60 shrink-0" />
+              <input
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if ((e.key === "Enter" || e.key === ",") && tagInput.trim()) {
+                    e.preventDefault();
+                    const newTag = tagInput.trim().replace(/,$/, "");
+                    if (newTag && !tags.includes(newTag)) {
+                      setTags([...tags, newTag]);
+                    }
+                    setTagInput("");
+                  }
+                }}
+                onBlur={() => {
+                  const newTag = tagInput.trim().replace(/,$/, "");
+                  if (newTag && !tags.includes(newTag)) {
+                    setTags([...tags, newTag]);
+                  }
+                  setTagInput("");
+                }}
+                placeholder="Add tags (press Enter or comma)"
+                className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/40"
+              />
+            </div>
           </div>
         </div>
 

--- a/src/features/tasks/components/task-detail-content.tsx
+++ b/src/features/tasks/components/task-detail-content.tsx
@@ -115,6 +115,23 @@ export function TaskDetailContent({
           </PropertyRow>
         )}
 
+        {/* Tags */}
+        {task.tags && task.tags.length > 0 && (
+          <PropertyRow icon={<Tag className="size-4 text-indigo-500" />} label="Tags">
+            <div className="flex flex-wrap gap-1">
+              {task.tags.map((tag, i) => (
+                <Badge
+                  key={i}
+                  variant="outline"
+                  className="text-xs font-medium bg-indigo-500/10 border-indigo-500/20 text-indigo-500"
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          </PropertyRow>
+        )}
+
         {/* Recurrence */}
         {task.recurrence && (
           <PropertyRow icon={<Repeat className="size-4 text-[#e44232]" />} label="Repeats">

--- a/src/features/tasks/components/task-item.tsx
+++ b/src/features/tasks/components/task-item.tsx
@@ -248,6 +248,18 @@ export function TaskItem({
             </span>
           )}
 
+          {/* Tags */}
+          {task.tags && task.tags.length > 0 &&
+            task.tags.map((tag, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-indigo-500/10 text-indigo-500 font-medium"
+              >
+                <Tag className="h-3 w-3" />
+                {tag}
+              </span>
+            ))}
+
           {/* AI Generated tag */}
           {task.description?.includes("[AI Generated]") && (
             <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-[#e44232]/10 text-[#e44232] font-medium">

--- a/src/features/tasks/components/task-item.tsx
+++ b/src/features/tasks/components/task-item.tsx
@@ -9,6 +9,7 @@ import {
   Tag,
   RotateCcw,
   Sparkles,
+  AlertCircle,
 } from "lucide-react";
 import { cn } from "@/shared/lib/utils";
 import { Button } from "@/shared/components/ui/button";
@@ -58,8 +59,8 @@ const formatDueDate = (dueDate: string): { text: string; color: string; isPastDu
 
     if (isPast(taskDate) && taskDate < now) {
       return {
-        text: format(date, "MMM d"),
-        color: "text-red-500 bg-red-500/10",
+        text: `Overdue \u00b7 ${format(date, "MMM d")}`,
+        color: "text-red-500 bg-red-500/10 font-semibold",
         isPastDue: true,
       };
     }
@@ -222,7 +223,11 @@ export function TaskItem({
                 dueDateInfo.color
               )}
             >
-              <Calendar className="h-3 w-3" />
+              {dueDateInfo.isPastDue ? (
+                <AlertCircle className="h-3 w-3" />
+              ) : (
+                <Calendar className="h-3 w-3" />
+              )}
               {dueDateInfo.text}
             </span>
           )}

--- a/src/features/tasks/components/task-list.tsx
+++ b/src/features/tasks/components/task-list.tsx
@@ -1,10 +1,19 @@
 import * as React from "react";
-import { Plus } from "lucide-react";
+import { Plus, ArrowUpDown, Check } from "lucide-react";
 import { cn } from "@/shared/lib/utils";
 import { Button } from "@/shared/components/ui/button";
 import { ScrollArea } from "@/shared/components/ui/scroll-area";
+import { Skeleton } from "@/shared/components/ui/skeleton";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/components/ui/dropdown-menu";
 import { TaskItem } from "@/features/tasks/components/task-item";
 import type { CalendarTask } from "@/features/tasks/types/task.types";
+
+export type SortBy = "default" | "dueDate" | "priority" | "alphabetical";
 
 export interface TaskListProps {
   title?: string;
@@ -23,6 +32,7 @@ export interface TaskListProps {
   className?: string;
   loading?: boolean;
   groupBy?: "none" | "priority" | "dueDate" | "project" | "category";
+  defaultSortBy?: SortBy;
 }
 
 const groupTasks = (tasks: CalendarTask[], groupBy: string): [string, CalendarTask[]][] => {
@@ -98,6 +108,33 @@ const groupTasks = (tasks: CalendarTask[], groupBy: string): [string, CalendarTa
   });
 };
 
+const sortTasks = (tasks: CalendarTask[], sortBy: SortBy): CalendarTask[] => {
+  if (sortBy === "default") return tasks;
+  return [...tasks].sort((a, b) => {
+    switch (sortBy) {
+      case "dueDate": {
+        if (!a.dueDate && !b.dueDate) return 0;
+        if (!a.dueDate) return 1;
+        if (!b.dueDate) return -1;
+        return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+      }
+      case "priority":
+        return b.priority - a.priority;
+      case "alphabetical":
+        return a.title.localeCompare(b.title);
+      default:
+        return 0;
+    }
+  });
+};
+
+const sortLabels: Record<SortBy, string> = {
+  default: "Default",
+  dueDate: "Due Date",
+  priority: "Priority",
+  alphabetical: "A-Z",
+};
+
 export function TaskList({
   title,
   tasks,
@@ -115,10 +152,14 @@ export function TaskList({
   className,
   loading = false,
   groupBy = "none",
+  defaultSortBy = "default",
 }: TaskListProps) {
+  const [sortBy, setSortBy] = React.useState<SortBy>(defaultSortBy);
+
   const groupedTasks = React.useMemo(() => {
-    return groupTasks(tasks, groupBy);
-  }, [tasks, groupBy]);
+    const groups = groupTasks(tasks, groupBy);
+    return groups.map(([name, groupItems]) => [name, sortTasks(groupItems, sortBy)] as [string, CalendarTask[]]);
+  }, [tasks, groupBy, sortBy]);
 
   const isEmpty = tasks.length === 0;
 
@@ -130,6 +171,22 @@ export function TaskList({
           {title && <h1 className="text-2xl font-bold">{title}</h1>}
           <div className="flex items-center gap-2">
             {headerActions}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" className="gap-1.5">
+                  <ArrowUpDown className="h-3.5 w-3.5" />
+                  <span className="hidden sm:inline">{sortLabels[sortBy]}</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {(Object.keys(sortLabels) as SortBy[]).map((key) => (
+                  <DropdownMenuItem key={key} onClick={() => setSortBy(key)}>
+                    <Check className={cn("h-3.5 w-3.5 mr-2", sortBy === key ? "opacity-100" : "opacity-0")} />
+                    {sortLabels[key]}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
             {onAddTask && (
               <Button
                 onClick={onAddTask}
@@ -156,13 +213,25 @@ export function TaskList({
       <ScrollArea className="flex-1">
         <div className="p-6">
           {loading ? (
-            <div className="space-y-3">
+            <div className="space-y-2">
               {[...Array(5)].map((_, i) => (
                 <div
                   key={i}
-                  className="h-14 rounded-lg bg-muted animate-pulse"
-                  style={{ animationDelay: `${i * 0.1}s` }}
-                />
+                  className="flex items-center gap-3 px-4 py-3 rounded-lg"
+                  style={{ opacity: 1 - i * 0.15 }}
+                >
+                  {/* Checkbox circle */}
+                  <Skeleton className="h-5 w-5 rounded-full shrink-0" />
+                  <div className="flex-1 space-y-2">
+                    {/* Title */}
+                    <Skeleton className="h-4 rounded" style={{ width: `${65 - i * 8}%` }} />
+                    {/* Metadata row */}
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-3 w-16 rounded" />
+                      <Skeleton className="h-3 w-20 rounded" />
+                    </div>
+                  </div>
+                </div>
               ))}
             </div>
           ) : isEmpty ? (

--- a/src/features/tasks/services/task.service.ts
+++ b/src/features/tasks/services/task.service.ts
@@ -78,12 +78,23 @@ function taskToDocument(task: Omit<CalendarTask, "id">, userId: string) {
     reminderEnabled: task.reminderEnabled ?? false,
     reminderBefore: task.reminderBefore || null,
   };
+  if (task.tags && task.tags.length > 0) doc.tags = JSON.stringify(task.tags);
   // Only include these if they have values — avoids "Unknown attribute" errors
   // if the collection hasn't been updated with these fields yet
   if (task.recurrence) doc.recurrence = task.recurrence;
   if (task.attachments && task.attachments.length > 0)
     doc.attachments = JSON.stringify(task.attachments);
   return doc;
+}
+
+function safeParseArray(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === "string");
+  } catch {
+    return [];
+  }
 }
 
 function safeParseSubtasks(raw: string): Subtask[] {
@@ -127,6 +138,7 @@ function documentToTask(doc: any): CalendarTask {
     subtasks: doc.subtasks ? safeParseSubtasks(doc.subtasks) : undefined,
     reminderEnabled: doc.reminderEnabled ?? false,
     reminderBefore: (doc.reminderBefore as ReminderBefore) || undefined,
+    tags: doc.tags ? safeParseArray(doc.tags) : undefined,
     recurrence: (doc.recurrence as Recurrence) || null,
     attachments: doc.attachments ? safeParseAttachments(doc.attachments) : undefined,
   };
@@ -223,6 +235,10 @@ export const taskService = {
       }
       if (updates.reminderBefore !== undefined) {
         updatePayload.reminderBefore = updates.reminderBefore || null;
+      }
+      if (updates.tags !== undefined) {
+        updatePayload.tags =
+          updates.tags && updates.tags.length > 0 ? JSON.stringify(updates.tags) : null;
       }
       if (updates.recurrence !== undefined && updates.recurrence) {
         updatePayload.recurrence = updates.recurrence;
@@ -422,6 +438,7 @@ export const taskService = {
         endTime: task.endTime,
         priority: task.priority,
         category: task.category,
+        tags: task.tags,
         project: task.project,
         status: "todo",
         subtasks: task.subtasks?.map((s) => ({ ...s, completed: false })),

--- a/src/features/tasks/types/task.types.ts
+++ b/src/features/tasks/types/task.types.ts
@@ -33,6 +33,7 @@ export interface CalendarTask {
   subtasks?: Subtask[];
   reminderEnabled?: boolean;
   reminderBefore?: ReminderBefore;
+  tags?: string[];
   recurrence?: Recurrence | null;
   attachments?: Attachment[];
 }

--- a/src/routes/_protected/projects/$projectId.tsx
+++ b/src/routes/_protected/projects/$projectId.tsx
@@ -135,6 +135,28 @@ function ProjectDetailPage() {
         onUpdate={handleUpdateProject}
       />
 
+      {/* Progress Bar */}
+      {projectTasks.length > 0 && (() => {
+        const completed = projectTasks.filter((t) => t.status === "completed").length;
+        const total = projectTasks.length;
+        const percent = Math.round((completed / total) * 100);
+        return (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">
+                {completed} of {total} task{total !== 1 ? "s" : ""} completed ({percent}%)
+              </span>
+            </div>
+            <div className="h-2 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full rounded-full bg-[#e44232] transition-all duration-500 ease-out"
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+          </div>
+        );
+      })()}
+
       <ProjectStatCards tasks={projectTasks} />
       <ProjectCharts tasks={projectTasks} />
 

--- a/src/routes/_protected/projects/$projectId.tsx
+++ b/src/routes/_protected/projects/$projectId.tsx
@@ -135,28 +135,6 @@ function ProjectDetailPage() {
         onUpdate={handleUpdateProject}
       />
 
-      {/* Progress Bar */}
-      {projectTasks.length > 0 && (() => {
-        const completed = projectTasks.filter((t) => t.status === "completed").length;
-        const total = projectTasks.length;
-        const percent = Math.round((completed / total) * 100);
-        return (
-          <div className="space-y-2">
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-muted-foreground">
-                {completed} of {total} task{total !== 1 ? "s" : ""} completed ({percent}%)
-              </span>
-            </div>
-            <div className="h-2 rounded-full bg-muted overflow-hidden">
-              <div
-                className="h-full rounded-full bg-[#e44232] transition-all duration-500 ease-out"
-                style={{ width: `${percent}%` }}
-              />
-            </div>
-          </div>
-        );
-      })()}
-
       <ProjectStatCards tasks={projectTasks} />
       <ProjectCharts tasks={projectTasks} />
 


### PR DESCRIPTION
This pull request introduces a comprehensive tags feature for tasks, improves task list usability with sorting options, and enhances the user interface for better clarity and feedback. The main changes are grouped below:

**Tags Feature for Tasks**

* Added a `tags` field to the task schema in the database and the `CalendarTask` type, enabling tasks to have associated tags. [[1]](diffhunk://#diff-8356663778579893fc3daef58117a177dc6762b1f77eb7da348f6295a30e854eR223) [[2]](diffhunk://#diff-a2ee4890ffefc3f2a78e82f21f4157b8a311ddf24dbe37a737ae0b90f707975aR36)
* Implemented tag input, display, and management in the task creation and editing dialog (`TaskAddDialog`), including UI for adding/removing tags and persisting them to the backend. [[1]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R125-R126) [[2]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R139) [[3]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R163-R164) [[4]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R247) [[5]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R496-R542) [[6]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR81) [[7]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR90-R99) [[8]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR141) [[9]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR239-R242) [[10]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR441)
* Displayed tags in the task detail view (`TaskDetailContent`) and in the task list item (`TaskItem`) for quick visibility. [[1]](diffhunk://#diff-e390f099ca16d6e8f4662fc98f9b8de5400233517e436685d68a103764ec7b10R118-R134) [[2]](diffhunk://#diff-932fa968ff2872920fd2ed90b1ea3ead3ce9e0d2e7a335d5bb13ea066602eac0R251-R262)

**Task List Usability Improvements**

* Added sorting options (default, due date, priority, alphabetical) to the task list, with a dropdown menu for user selection and logic to sort tasks accordingly. [[1]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3L2-R17) [[2]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3R35) [[3]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3R111-R137) [[4]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3R155-R162) [[5]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3R174-R189)
* Enhanced the loading state of the task list with more detailed skeleton placeholders for a better user experience.

**User Interface and Feedback Enhancements**

* Improved overdue task indication by updating the due date format and adding an alert icon for overdue tasks. [[1]](diffhunk://#diff-932fa968ff2872920fd2ed90b1ea3ead3ce9e0d2e7a335d5bb13ea066602eac0R12) [[2]](diffhunk://#diff-932fa968ff2872920fd2ed90b1ea3ead3ce9e0d2e7a335d5bb13ea066602eac0L61-R63) [[3]](diffhunk://#diff-932fa968ff2872920fd2ed90b1ea3ead3ce9e0d2e7a335d5bb13ea066602eac0R226-R230)
* Added entry animation to the empty state component for tasks.

**Dependency and Import Fixes**

* Updated import statements throughout the API to use explicit `.js` extensions for compatibility. [[1]](diffhunk://#diff-e61c491cf4419f5d7a8848108fff5dcd43f4e2c4d158113d8b5236b74157dbfeL2-R4) [[2]](diffhunk://#diff-031027f3924e7602b2a0cc513d2367cf69ec034b23f3c381da1a37465138d246L2-R2) [[3]](diffhunk://#diff-37282e567b93af8049a9ef1517848a0b6825a1e8ee4c19f6e2abc8245d13030bL2-R2)

(References: [[1]](diffhunk://#diff-8356663778579893fc3daef58117a177dc6762b1f77eb7da348f6295a30e854eR223) [[2]](diffhunk://#diff-a2ee4890ffefc3f2a78e82f21f4157b8a311ddf24dbe37a737ae0b90f707975aR36) [[3]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R125-R126) [[4]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R139) [[5]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R163-R164) [[6]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R247) [[7]](diffhunk://#diff-56ac8f849759550a3b463c42899b727ed46cb937054dcfc801e59ae8db3c2ef7R496-R542) [[8]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR81) [[9]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR90-R99) [[10]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR141) [[11]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR239-R242) [[12]](diffhunk://#diff-cbb75b65069d06e68295450717b687c091de57f497ff1db3a965c7259009540aR441) [[13]](diffhunk://#diff-e390f099ca16d6e8f4662fc98f9b8de5400233517e436685d68a103764ec7b10R118-R134) [[14]](diffhunk://#diff-932fa968ff2872920fd2ed90b1ea3ead3ce9e0d2e7a335d5bb13ea066602eac0R251-R262) [[15]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3L2-R17) [[16]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3R35) [[17]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3R111-R137) [[18]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3R155-R162) [[19]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3R174-R189) [[20]](diffhunk://#diff-e8b6bb90a2f3cef902613b5f4c33d663940ccdf9f16eeb6c95283f59cf01ffc3L159-R234) [[21]](diffhunk://#diff-932fa968ff2872920fd2ed90b1ea3ead3ce9e0d2e7a335d5bb13ea066602eac0R12) [[22]](diffhunk://#diff-932fa968ff2872920fd2ed90b1ea3ead3ce9e0d2e7a335d5bb13ea066602eac0L61-R63) [[23]](diffhunk://#diff-932fa968ff2872920fd2ed90b1ea3ead3ce9e0d2e7a335d5bb13ea066602eac0R226-R230) [[24]](diffhunk://#diff-a80744b763c9dd5b5013c5beba6047ebca80a0367dc4a1582dd1a62f821849f2L27-R27) [[25]](diffhunk://#diff-e61c491cf4419f5d7a8848108fff5dcd43f4e2c4d158113d8b5236b74157dbfeL2-R4) [[26]](diffhunk://#diff-031027f3924e7602b2a0cc513d2367cf69ec034b23f3c381da1a37465138d246L2-R2) [[27]](diffhunk://#diff-37282e567b93af8049a9ef1517848a0b6825a1e8ee4c19f6e2abc8245d13030bL2-R2)